### PR TITLE
chore: gitignore local planning workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ test_install
 inst/doc
 docs
 dev_untrack.R
+.Rproj.user
+
+# Private planning workspace (see local/README.md)
+local/


### PR DESCRIPTION
Adds `local/` (private, untracked planning workspace) and `.Rproj.user` to `.gitignore`.

- `local/` holds strategic planning docs (project review, gaps, roadmap, backlog) that should live beside the repo but never be committed.
- `.Rproj.user` is the standard RStudio per-user state dir (was already staged locally).

No package source or behavior changes.