### PR TITLE
style: adopt Air formatter

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,5 @@
 ^pkgdown$
 ^\.github$
 ^dev_untrack\.R$
+^air\.toml$
+^local$

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,21 @@
+# Check that R/ is formatted with Air (https://posit-dev.github.io/air/)
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: format.yaml
+
+permissions: read-all
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: posit-dev/setup-air@v1
+
+      - name: Check R/ formatting
+        run: air format --check R

--- a/R/init_changelog_md.R
+++ b/R/init_changelog_md.R
@@ -8,23 +8,20 @@
 #'
 #' @examples
 #' init_changelog_md()
-init_changelog_md <- function(path = getwd(), confirm = TRUE){
-
-
+init_changelog_md <- function(path = getwd(), confirm = TRUE) {
   # Display a message before the prompt
   cat("You current working directory will be:\n")
   cat(path)
 
-  if(confirm){
+  if (confirm) {
     user_input <- tolower(
       readline(
         prompt = "Do you wish to create a Change log MD here? (y/yes to confirm): "
       )
     )
-  }else{
+  } else {
     user_input <- "y"
   }
-
 
   # Check if the user input is 'y' or 'yes'
   if (user_input %in% c("y", "yes")) {
@@ -40,10 +37,10 @@ YYYY-MM-DD  John Doe
 * Another Change 2
 ```
     "
-    aa <- file.path(wd_path,"CHANGELOG.md")
+    aa <- file.path(wd_path, "CHANGELOG.md")
     file.create(aa, showWarnings = FALSE)
 
-    if(file.exists(aa)){
+    if (file.exists(aa)) {
       fileConn <- file(aa)
 
       writeLines(
@@ -51,11 +48,8 @@ YYYY-MM-DD  John Doe
         fileConn
       )
       close(fileConn)
-
     }
-
   } else {
     cat("Change log MD initialization canceled.\n")
   }
-
 }

--- a/R/init_shiny.R
+++ b/R/init_shiny.R
@@ -10,174 +10,175 @@
 #' }
 #'
 #' @export
-init_shiny <- function(path = getwd(), confirm = TRUE){
-
-
+init_shiny <- function(path = getwd(), confirm = TRUE) {
   # Display a message before the prompt
   cat("You current working directory will be:\n")
   cat(path)
 
-  if(confirm){
+  if (confirm) {
     user_input <- tolower(
       readline(
         prompt = "Do you wish to create a project template here? (y/yes to confirm): "
       )
     )
-  }else{
+  } else {
     user_input <- "y"
   }
-
 
   # Check if the user input is 'y' or 'yes'
   if (user_input %in% c("y", "yes")) {
     wd_path <- path
-    dir.create(file.path(wd_path), recursive = TRUE,
-               showWarnings = FALSE)
-    shiny_dir_comp <- c("www","data","modules",
-                        "userInterface","R","dev")
+    dir.create(file.path(wd_path), recursive = TRUE, showWarnings = FALSE)
+    shiny_dir_comp <- c("www", "data", "modules", "userInterface", "R", "dev")
 
-    shiny_file_comp <- c("ui.R","server.R",
-                         "global.R", "Dockerfile",
-                         "modules/test_mod.R",
-                         "userInterface/home_ui.R",
-                         "userInterface/other_ui.R",
-                         "R/load_components.R",
-                         "dev/dev.R",
-                         ".gitignore", ".Renviron")
+    shiny_file_comp <- c(
+      "ui.R",
+      "server.R",
+      "global.R",
+      "Dockerfile",
+      "modules/test_mod.R",
+      "userInterface/home_ui.R",
+      "userInterface/other_ui.R",
+      "R/load_components.R",
+      "dev/dev.R",
+      ".gitignore",
+      ".Renviron"
+    )
 
     #www_path <- file.path(wd_path,"www")
-    www_contents <- c("css","img","js")
+    www_contents <- c("css", "img", "js")
 
-    global_con <- c("# Load libraries/ Source Files",
-                    "library(shiny)",
-                    " ",
-                    "# Load data/connections",
-                    " ",
-                    "# Preprocess small data",
-                    " "
+    global_con <- c(
+      "# Load libraries/ Source Files",
+      "library(shiny)",
+      " ",
+      "# Load data/connections",
+      " ",
+      "# Preprocess small data",
+      " "
     )
-    ui_con <- c("navbarPage(",
-                "     'My app',",
-                "     tabPanel('Home', home_page),",
-                "     tabPanel('Other', other_page),",
-                ")"
+    ui_con <- c(
+      "navbarPage(",
+      "     'My app',",
+      "     tabPanel('Home', home_page),",
+      "     tabPanel('Other', other_page),",
+      ")"
     )
-    server_con <- c("# Shiny Server",
-                    "function(input, output, session) {",
-                    " ",
-                    "}"
+    server_con <- c(
+      "# Shiny Server",
+      "function(input, output, session) {",
+      " ",
+      "}"
     )
-    docker_con <- c("# Base R Shiny image",
-                    "FROM rocker/shiny",
-                    " ",
-                    "# Install R dependencies",
-                    "RUN R -e 'install.packages()'",
-                    " ",
-                    "RUN mkdir home/my_app",
-                    " ",
-                    "# Copy the Shiny app code",
-                    "COPY *.R /home/my_app",
-                    " ",
-                    "# Expose the application port",
-                    "EXPOSE 3838",
-                    " ",
-                    "# Run the R Shiny app",
-                    "CMD R -e 'shiny::runApp(`/home/my_app`,port = 3838, host = `0.0.0.0`)'"
+    docker_con <- c(
+      "# Base R Shiny image",
+      "FROM rocker/shiny",
+      " ",
+      "# Install R dependencies",
+      "RUN R -e 'install.packages()'",
+      " ",
+      "RUN mkdir home/my_app",
+      " ",
+      "# Copy the Shiny app code",
+      "COPY *.R /home/my_app",
+      " ",
+      "# Expose the application port",
+      "EXPOSE 3838",
+      " ",
+      "# Run the R Shiny app",
+      "CMD R -e 'shiny::runApp(`/home/my_app`,port = 3838, host = `0.0.0.0`)'"
     )
     test_mod <- c("# Use shinymod to generate module template")
 
-    git_ign_con <- c(".Rproj.user",
-                     ".Rhistory",
-                     ".RData",
-                     ".Ruserdata"
+    git_ign_con <- c(".Rproj.user", ".Rhistory", ".RData", ".Ruserdata")
+
+    load_components <- c(
+      "# Load modules",
+      "sapply(list.files('modules', full.names = TRUE), function(x) source(x))",
+      "# Load user interface",
+      "sapply(list.files('userInterface', full.names = TRUE), function(x) source(x))",
+      " "
     )
 
-    load_components <- c("# Load modules",
-                         "sapply(list.files('modules', full.names = TRUE), function(x) source(x))",
-                         "# Load user interface",
-                         "sapply(list.files('userInterface', full.names = TRUE), function(x) source(x))",
-                         " "
-                         )
-
-    home_userInterface <- c("home_page <- fluidPage(",
-                            "# Page title",
-                            "titlePanel('Home Page'),",
-                            "hr(),",
-                            "fluidRow(",
-                            "   column(6,h2('Column size 3')),",
-                            "   column(6,h2('Column size 6'))",
-                            " )",
-                            ")"
-                            )
-
-    other_userInterface <- c("other_page <- fluidPage(",
-                            "# Page title",
-                            "titlePanel('Other Page'),",
-                            "hr(),",
-                            "fluidRow(",
-                            "   column(6,h2('Column size 3')),",
-                            "   column(6,h2('Column size 6'))",
-                            " )",
-                            ")"
+    home_userInterface <- c(
+      "home_page <- fluidPage(",
+      "# Page title",
+      "titlePanel('Home Page'),",
+      "hr(),",
+      "fluidRow(",
+      "   column(6,h2('Column size 3')),",
+      "   column(6,h2('Column size 6'))",
+      " )",
+      ")"
     )
 
-    dev_r <- c("# Use this script to test code blocks for app dev.",
-               "# Make sure to add this 'dev' directory",
-               "# in your gitignore after template initialization."
-               )
+    other_userInterface <- c(
+      "other_page <- fluidPage(",
+      "# Page title",
+      "titlePanel('Other Page'),",
+      "hr(),",
+      "fluidRow(",
+      "   column(6,h2('Column size 3')),",
+      "   column(6,h2('Column size 6'))",
+      " )",
+      ")"
+    )
 
-    Renviron <- c("#Delete this line and enter variables with secret keys/tokens etc.")
+    dev_r <- c(
+      "# Use this script to test code blocks for app dev.",
+      "# Make sure to add this 'dev' directory",
+      "# in your gitignore after template initialization."
+    )
+
+    Renviron <- c(
+      "#Delete this line and enter variables with secret keys/tokens etc."
+    )
     # generate shiny project dir
     sapply(shiny_dir_comp, function(x) {
-
-      aa <- file.path(wd_path,x)
+      aa <- file.path(wd_path, x)
       dir.create(aa, recursive = TRUE, showWarnings = FALSE)
 
-      if(x == "www"){
+      if (x == "www") {
         sapply(www_contents, function(x) {
-
-          bb <- file.path(aa,x)
+          bb <- file.path(aa, x)
           dir.create(bb, recursive = TRUE, showWarnings = FALSE)
-
         })
       }
-
     })
 
     # generate shiny project files
 
     sapply(shiny_file_comp, function(x) {
-
-      aa <- file.path(wd_path,x)
+      aa <- file.path(wd_path, x)
       file.create(aa, showWarnings = FALSE)
 
       # print("In file write function")
       # print(aa)
       # Write to file
-      if(file.exists(aa)){
+      if (file.exists(aa)) {
         fileConn <- file(aa)
 
-        if(x == "global.R"){
+        if (x == "global.R") {
           y <- global_con
-        }else if(x == "ui.R"){
+        } else if (x == "ui.R") {
           y <- ui_con
-        }else if(x == "server.R"){
+        } else if (x == "server.R") {
           y <- server_con
-        }else if(x == "modules/test_mod.R"){
+        } else if (x == "modules/test_mod.R") {
           y <- test_mod
-        }else if(x == "Dockerfile"){
+        } else if (x == "Dockerfile") {
           y <- docker_con
-        }else if(x == "userInterface/home_ui.R"){
+        } else if (x == "userInterface/home_ui.R") {
           y <- home_userInterface
-        }else if(x == "userInterface/other_ui.R"){
+        } else if (x == "userInterface/other_ui.R") {
           y <- other_userInterface
-        }else if(x == "R/load_components.R"){
+        } else if (x == "R/load_components.R") {
           y <- load_components
-        }else if(x == "dev/dev.R"){
+        } else if (x == "dev/dev.R") {
           y <- dev_r
-        }else if(x == ".gitignore"){
+        } else if (x == ".gitignore") {
           y <- git_ign_con
-        }else if(x == ".Renviron"){
+        } else if (x == ".Renviron") {
           y <- Renviron
         }
 
@@ -186,17 +187,12 @@ init_shiny <- function(path = getwd(), confirm = TRUE){
           fileConn
         )
         close(fileConn)
-
       }
-    }
-    )
+    })
     cat("Project initialized.\n")
     cat("Please see documentation at:\n")
     cat("https://www.samuelbharti.com/posts/r-shiny-template/")
-  }
-  else {
+  } else {
     cat("Project initialization canceled.\n")
   }
-
-
 }

--- a/R/init_template.R
+++ b/R/init_template.R
@@ -14,69 +14,69 @@
 #' }
 #' @keywords internal
 init_template <- function(template_name, path = getwd(), confirm = TRUE) {
-
   # Display a message before the prompt
   cat("You current working directory will be:\n")
   cat(path)
 
-  if(confirm){
+  if (confirm) {
     user_input <- tolower(
       readline(
         prompt = "Do you wish to create a project template here? (y/yes to confirm): "
       )
     )
-  }else{
+  } else {
     user_input <- "y"
   }
 
   if (user_input %in% c("y", "yes")) {
+    dest_dir <- path
 
-  dest_dir = path
+    if (template_name == "shiny") {
+      repo_url <- "https://github.com/samuelbharti/RShiny_template"
+      doc_url <- "https://www.samuelbharti.com/posts/r-shiny-template/"
+    } else if (template_name == "cgds") {
+      repo_url <- "https://github.com/uab-cgds-worthey/cgds_repo_template"
+      doc_url <- repo_url
+    }
 
-  if(template_name == "shiny"){
-    repo_url = "https://github.com/samuelbharti/RShiny_template"
-    doc_url = "https://www.samuelbharti.com/posts/r-shiny-template/"
-  }else if(template_name == "cgds"){
-    repo_url = "https://github.com/uab-cgds-worthey/cgds_repo_template"
-    doc_url = repo_url
-  }
+    # Modify the GitHub repo URL to point to the ZIP file
+    zip_url <- paste0(repo_url, "/archive/refs/heads/main.zip")
 
-  # Modify the GitHub repo URL to point to the ZIP file
-  zip_url <- paste0(repo_url, "/archive/refs/heads/main.zip")
+    # Define the path where the ZIP file will be saved
+    temp_dir <- file.path(paste0(dest_dir, "/temp_dir"))
+    dir.create(temp_dir)
 
-  # Define the path where the ZIP file will be saved
-  temp_dir <- file.path(paste0(dest_dir,"/temp_dir"))
-  dir.create(temp_dir)
+    zip_dest <- file.path(temp_dir, "repo.zip") # Save ZIP file in a temporary directory
 
-  zip_dest <- file.path(temp_dir, "repo.zip")  # Save ZIP file in a temporary directory
+    # Download the ZIP file
+    download.file(url = zip_url, destfile = zip_dest, mode = "wb", quiet = TRUE)
 
-  # Download the ZIP file
-  download.file(url =  zip_url, destfile =  zip_dest, mode = "wb", quiet = TRUE)
+    # Extract the ZIP file into a temporary directory
+    unzip(zip_dest, exdir = temp_dir)
 
-  # Extract the ZIP file into a temporary directory
-  unzip(zip_dest, exdir = temp_dir)
+    # Get the name of the unzipped folder (it usually contains "-main" or "-master" at the end)
+    unzipped_folder <- list.dirs(temp_dir, recursive = FALSE)[1] # Assuming the first folder is the repo
 
-  # Get the name of the unzipped folder (it usually contains "-main" or "-master" at the end)
-  unzipped_folder <- list.dirs(temp_dir, recursive = FALSE)[1]  # Assuming the first folder is the repo
+    # Copy the contents from the unzipped folder to the destination directory
+    file.copy(
+      list.files(
+        unzipped_folder,
+        full.names = TRUE,
+        include.dirs = TRUE,
+        all.files = TRUE,
+        no.. = TRUE
+      ),
+      to = dest_dir,
+      recursive = TRUE
+    )
 
-  # Copy the contents from the unzipped folder to the destination directory
-  file.copy(list.files(unzipped_folder,
-                       full.names = TRUE,
-                       include.dirs = TRUE,
-                       all.files = TRUE, no.. = TRUE),
-            to = dest_dir,
-            recursive = TRUE)
+    # Remove the ZIP file after extraction
+    unlink(temp_dir, recursive = TRUE)
 
-  # Remove the ZIP file after extraction
-  unlink(temp_dir, recursive = TRUE)
-
-  cat("Project initialized.\n")
-  cat("Please see documentation at: \n")
-  cat(doc_url)
-
+    cat("Project initialized.\n")
+    cat("Please see documentation at: \n")
+    cat(doc_url)
   } else {
     cat("Project initialization canceled.\n")
   }
-
-
 }

--- a/R/init_tool_review.R
+++ b/R/init_tool_review.R
@@ -13,86 +13,75 @@
 #' \dontrun{
 #' tool_review_template("abc","www.abc.com")
 #' }
-tool_review_template <- function(tool_name, tool_url, path = getwd(),
-                                 confirm = TRUE, ...){
-
+tool_review_template <- function(
+  tool_name,
+  tool_url,
+  path = getwd(),
+  confirm = TRUE,
+  ...
+) {
   cat("You current working directory will be:\n")
   cat(path)
 
-  if(confirm){
+  if (confirm) {
     user_input <- tolower(
       readline(
         prompt = "Do you wish to create a project template here? (y/yes to confirm): "
       )
     )
-  }else{
+  } else {
     user_input <- "y"
   }
 
   if (user_input %in% c("y", "yes")) {
-
-
-    if(length(tool_name) != length(tool_url)){
+    if (length(tool_name) != length(tool_url)) {
       print("Please provide URL or Empty qoutes for Each tool")
       return(invisible(NULL))
     }
 
-    base_dir <- c("src","data","notebooks","configs","out","docs")
-    data_dir <- c("shared","preprocessed","other","")
+    base_dir <- c("src", "data", "notebooks", "configs", "out", "docs")
+    data_dir <- c("shared", "preprocessed", "other", "")
 
-
-    script_comment <- function(x_name, x_url){
+    script_comment <- function(x_name, x_url) {
       t_name <- paste0("# Tool name: ", x_name)
       t_url <- paste0("# Tool URL: ", x_url)
-      t_comment <- c("########",
-                     t_name,
-                     t_url,
-                     "########")
+      t_comment <- c("########", t_name, t_url, "########")
       return(t_comment)
     }
 
     wd_path <- path
 
     sapply(base_dir, function(x) {
-
-      aa <- file.path(wd_path,x)
+      aa <- file.path(wd_path, x)
       dir.create(aa, recursive = TRUE, showWarnings = FALSE)
 
-      if(x == "data"){
+      if (x == "data") {
         sapply(data_dir, function(x) {
-
-          bb <- file.path(aa,x)
-          dir.create(bb, recursive = TRUE, showWarnings = FALSE)
-
-          if(x == "preprocessed"){
-            sapply(tool_name, function(x){
-
-              cc <- file.path(bb, x)
-              dir.create(cc, recursive = TRUE, showWarnings = FALSE)
-
-            })
-          }
-
-        })
-      }
-
-      if(x == "out"){
-        sapply(tool_name, function(x){
-
           bb <- file.path(aa, x)
           dir.create(bb, recursive = TRUE, showWarnings = FALSE)
 
+          if (x == "preprocessed") {
+            sapply(tool_name, function(x) {
+              cc <- file.path(bb, x)
+              dir.create(cc, recursive = TRUE, showWarnings = FALSE)
+            })
+          }
         })
-
       }
 
-      if(x == "src"){
-        sapply(1:length(tool_name), function(x){
+      if (x == "out") {
+        sapply(tool_name, function(x) {
+          bb <- file.path(aa, x)
+          dir.create(bb, recursive = TRUE, showWarnings = FALSE)
+        })
+      }
 
-          bb <- file.path(aa, paste0(tool_name[x],".R"))
-          if(file.exists(bb)){
+      if (x == "src") {
+        sapply(1:length(tool_name), function(x) {
+          bb <- file.path(aa, paste0(tool_name[x], ".R"))
+          if (file.exists(bb)) {
             file_info <- file.info(bb)
-            if(is.na(file_info$size) || file_info$size == 0){
+            if (is.na(file_info$size) || file_info$size == 0) {
               # fileConn <- file(bb)
               # writeLines(
               #   script_comment(tool_name[x], tool_url[x]),
@@ -100,10 +89,10 @@ tool_review_template <- function(tool_name, tool_url, path = getwd(),
               # )
               # close(fileConn)
               cat("The file is empty. No changes made.\n")
-            }else {
+            } else {
               cat("The file is not empty. No changes made.\n")
             }
-          }else{
+          } else {
             file.create(bb, showWarnings = FALSE)
             fileConn <- file(bb)
             writeLines(
@@ -119,5 +108,3 @@ tool_review_template <- function(tool_name, tool_url, path = getwd(),
     cat("Project initialization canceled.\n")
   }
 }
-
-

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,6 @@
+# Air — R formatter (https://posit-dev.github.io/air/)
+# Tidyverse/Posit defaults, stated explicitly.
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"


### PR DESCRIPTION
Adopts [Air](https://posit-dev.github.io/air/) (Posit's R formatter) as the project formatter, per the tooling conventions.

**Changes**
- Add `air.toml` with explicit tidyverse/Posit defaults (line-width 80, 2-space indent).
- Ignore `air.toml` and `local/` in `.Rbuildignore` so they stay out of the built package.
- Apply `air format` to `R/` — whitespace/brace normalization, `c(...)` reflow, and statement-level `=` → `<-` (named call-arguments untouched).

**Safety:** formatting only — no logic or string-literal changes. `air format --check R/` is clean. Known bugs (e.g. `1:length()`, Dockerfile backticks) are intentionally left for separate `fix:` PRs.

_Note: R is not installed locally, so `R CMD check`/roxygen were not re-run here; CI (to be added) will cover that._