### PR TITLE
test: set up testthat with first test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,10 +12,12 @@ License: GPL-3 + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.3
-Suggests: 
+Suggests:
     knitr,
-    rmarkdown
+    rmarkdown,
+    testthat (>= 3.0.0)
 VignetteBuilder: knitr
+Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 Imports:
     utils

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/reference/test_package.html#special-files
+
+library(testthat)
+library(peacock)
+
+test_check("peacock")

--- a/tests/testthat/test-init_changelog_md.R
+++ b/tests/testthat/test-init_changelog_md.R
@@ -1,0 +1,11 @@
+test_that("init_changelog_md() writes a non-empty CHANGELOG.md at the given path", {
+  dir <- file.path(tempdir(), "peacock-changelog-test")
+  dir.create(dir, showWarnings = FALSE)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  init_changelog_md(path = dir, confirm = FALSE)
+
+  changelog <- file.path(dir, "CHANGELOG.md")
+  expect_true(file.exists(changelog))
+  expect_gt(file.size(changelog), 0)
+})


### PR DESCRIPTION
Establishes the test harness the package was missing (0 tests previously).

- `Suggests: testthat (>= 3.0.0)` + `Config/testthat/edition: 3` in DESCRIPTION.
- Standard `tests/testthat.R` runner.
- First test: `init_changelog_md()` writes a non-empty `CHANGELOG.md` at the given path (uses `tempdir()`, `confirm = FALSE`).

R-CMD-check now runs this test across all three OSes. Targeted tests for each bug will land alongside their `fix:` PRs.