### PR TITLE
fix: validate template_name in init_template()

### DIFF
--- a/R/init_template.R
+++ b/R/init_template.R
@@ -1,6 +1,6 @@
 #' Initialize a template repository from GitHub Templates
 #'
-#' @param template_name Name of template. "shiny", "cgds"
+#' @param template_name Name of template, one of "shiny" or "cgds". Defaults to "shiny".
 #' @param path Path where project template will be created.
 #' @param confirm Logical. If TRUE, prompts user for confirmation before creating template.
 #'
@@ -13,7 +13,13 @@
 #' init_template("shiny",getwd())
 #' }
 #' @keywords internal
-init_template <- function(template_name, path = getwd(), confirm = TRUE) {
+init_template <- function(
+  template_name = c("shiny", "cgds"),
+  path = getwd(),
+  confirm = TRUE
+) {
+  template_name <- match.arg(template_name)
+
   # Display a message before the prompt
   cat("You current working directory will be:\n")
   cat(path)

--- a/man/init_template.Rd
+++ b/man/init_template.Rd
@@ -4,10 +4,10 @@
 \alias{init_template}
 \title{Initialize a template repository from GitHub Templates}
 \usage{
-init_template(template_name, path = getwd(), confirm = TRUE)
+init_template(template_name = c("shiny", "cgds"), path = getwd(), confirm = TRUE)
 }
 \arguments{
-\item{template_name}{Name of template. "shiny", "cgds"}
+\item{template_name}{Name of template, one of "shiny" or "cgds". Defaults to "shiny".}
 
 \item{path}{Path where project template will be created.}
 

--- a/tests/testthat/test-init_template.R
+++ b/tests/testthat/test-init_template.R
@@ -1,0 +1,9 @@
+test_that("init_template() rejects an unknown template_name with a clear error", {
+  # Validation happens via match.arg() before any prompt or network download,
+  # so this never touches GitHub. The valid-name path is not tested here because
+  # it would download a real template repository.
+  expect_error(
+    init_template("nope", confirm = FALSE),
+    "should be one of"
+  )
+})


### PR DESCRIPTION
Fixes a crash where any `template_name` other than `"shiny"`/`"cgds"` left `repo_url` undefined, producing a cryptic `object 'repo_url' not found` error mid-run.

**Change**
- `template_name` now defaults to `c("shiny", "cgds")` and is validated with `match.arg()` at the top of the function — before any prompt or network call.
- Unknown names now fail fast with a clear `'arg' should be one of ...` message; a bare `init_template()` defaults to `"shiny"`.
- `man/init_template.Rd` hand-synced to the new signature (roxygen not run locally — no R here; kept in sync so the code/doc check stays green).

**Test:** `test-init_template.R` asserts an unknown name errors, without touching the network.