### PR TITLE
fix: use seq_along() in tool_review_template()

### DIFF
--- a/R/init_tool_review.R
+++ b/R/init_tool_review.R
@@ -77,7 +77,7 @@ tool_review_template <- function(
       }
 
       if (x == "src") {
-        sapply(1:length(tool_name), function(x) {
+        sapply(seq_along(tool_name), function(x) {
           bb <- file.path(aa, paste0(tool_name[x], ".R"))
           if (file.exists(bb)) {
             file_info <- file.info(bb)

--- a/tests/testthat/test-init_tool_review.R
+++ b/tests/testthat/test-init_tool_review.R
@@ -1,0 +1,18 @@
+test_that("tool_review_template() handles zero tools without error", {
+  # With `1:length(tool_name)` an empty `tool_name` produced `1:0` (c(1, 0)),
+  # which errored on the zero-length index. `seq_along()` yields integer(0),
+  # so no per-tool scripts are attempted.
+  dir <- file.path(tempdir(), "peacock-toolrev-empty")
+  dir.create(dir, showWarnings = FALSE)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  expect_no_error(
+    tool_review_template(
+      character(0),
+      character(0),
+      path = dir,
+      confirm = FALSE
+    )
+  )
+  expect_length(list.files(file.path(dir, "src"), pattern = "\\.R$"), 0)
+})


### PR DESCRIPTION
Fixes a crash on empty `tool_name`. `1:length(tool_name)` evaluated to `c(1, 0)` when `tool_name` was empty, so the `src/` loop indexed a zero-length vector and errored (and created a stray `NA.R`). `seq_along()` yields `integer(0)`, so no per-tool scripts are attempted.

**Test:** `test-init_tool_review.R` asserts zero tools runs without error and creates no `src/*.R`.