### PR TITLE
fix: correct Dockerfile CMD quoting in init_shiny()

### DIFF
--- a/R/init_shiny.R
+++ b/R/init_shiny.R
@@ -86,7 +86,7 @@ init_shiny <- function(path = getwd(), confirm = TRUE) {
       "EXPOSE 3838",
       " ",
       "# Run the R Shiny app",
-      "CMD R -e 'shiny::runApp(`/home/my_app`,port = 3838, host = `0.0.0.0`)'"
+      "CMD R -e 'shiny::runApp(\"/home/my_app\", port = 3838, host = \"0.0.0.0\")'"
     )
     test_mod <- c("# Use shinymod to generate module template")
 

--- a/tests/testthat/test-init_shiny.R
+++ b/tests/testthat/test-init_shiny.R
@@ -1,0 +1,15 @@
+test_that("init_shiny() writes a Dockerfile with a valid CMD (no backtick quoting)", {
+  dir <- file.path(tempdir(), "peacock-shiny-docker")
+  dir.create(dir, showWarnings = FALSE)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  init_shiny(path = dir, confirm = FALSE)
+
+  dockerfile <- readLines(file.path(dir, "Dockerfile"))
+  cmd <- grep("^CMD", dockerfile, value = TRUE)
+
+  expect_length(cmd, 1)
+  # Backticks would make R try to evaluate `/home/my_app` as a name.
+  expect_no_match(cmd, "`", fixed = TRUE)
+  expect_match(cmd, "/home/my_app", fixed = TRUE)
+})


### PR DESCRIPTION
The generated Shiny `Dockerfile` used backticks in the `CMD`:

```
CMD R -e 'shiny::runApp(`/home/my_app`,port = 3838, host = `0.0.0.0`)'
```

R treats backticks as non-syntactic *names*, so the container command would fail to launch the app. Now uses proper string quoting:

```
CMD R -e 'shiny::runApp("/home/my_app", port = 3838, host = "0.0.0.0")'
```

**Test:** `test-init_shiny.R` generates the app and asserts the `CMD` line has no backticks and points at `/home/my_app`.