### PR TITLE
fix: harden init_template() download I/O

### DIFF
--- a/R/init_template.R
+++ b/R/init_template.R
@@ -50,12 +50,30 @@ init_template <- function(
 
     # Define the path where the ZIP file will be saved
     temp_dir <- file.path(paste0(dest_dir, "/temp_dir"))
-    dir.create(temp_dir)
+    dir.create(temp_dir, showWarnings = FALSE)
+    # Always clean up the temporary download directory when the function exits
+    on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
 
     zip_dest <- file.path(temp_dir, "repo.zip") # Save ZIP file in a temporary directory
 
     # Download the ZIP file
-    download.file(url = zip_url, destfile = zip_dest, mode = "wb", quiet = TRUE)
+    tryCatch(
+      download.file(
+        url = zip_url,
+        destfile = zip_dest,
+        mode = "wb",
+        quiet = TRUE
+      ),
+      error = function(e) {
+        stop(
+          "Failed to download template from ",
+          zip_url,
+          ": ",
+          conditionMessage(e),
+          call. = FALSE
+        )
+      }
+    )
 
     # Extract the ZIP file into a temporary directory
     unzip(zip_dest, exdir = temp_dir)
@@ -75,9 +93,6 @@ init_template <- function(
       to = dest_dir,
       recursive = TRUE
     )
-
-    # Remove the ZIP file after extraction
-    unlink(temp_dir, recursive = TRUE)
 
     cat("Project initialized.\n")
     cat("Please see documentation at: \n")


### PR DESCRIPTION
Makes the template download robust:

- `on.exit(unlink(temp_dir, ...))` guarantees the temporary download dir is removed even if the download/unzip/copy fails partway (previously a mid-run failure left `temp_dir` behind).
- `download.file()` wrapped in `tryCatch()` so a network failure raises a clear `Failed to download template from <url>: ...` message instead of a raw error.
- `dir.create(temp_dir, showWarnings = FALSE)` silences the warning when the dir already exists.

_No unit test: this path performs a real network download and can't be exercised hermetically without adding a mocking dependency (out of scope for the essential pass). The example remains `\dontrun{}`, so R CMD check does not hit the network._