### PR TITLE
fix: only prompt for confirmation in interactive sessions

### DIFF
--- a/R/init_changelog_md.R
+++ b/R/init_changelog_md.R
@@ -7,13 +7,13 @@
 #' @export
 #'
 #' @examples
-#' init_changelog_md()
+#' init_changelog_md(path = tempdir(), confirm = FALSE)
 init_changelog_md <- function(path = getwd(), confirm = TRUE) {
   # Display a message before the prompt
   cat("You current working directory will be:\n")
   cat(path)
 
-  if (confirm) {
+  if (confirm && interactive()) {
     user_input <- tolower(
       readline(
         prompt = "Do you wish to create a Change log MD here? (y/yes to confirm): "

--- a/R/init_shiny.R
+++ b/R/init_shiny.R
@@ -15,7 +15,7 @@ init_shiny <- function(path = getwd(), confirm = TRUE) {
   cat("You current working directory will be:\n")
   cat(path)
 
-  if (confirm) {
+  if (confirm && interactive()) {
     user_input <- tolower(
       readline(
         prompt = "Do you wish to create a project template here? (y/yes to confirm): "

--- a/R/init_template.R
+++ b/R/init_template.R
@@ -24,7 +24,7 @@ init_template <- function(
   cat("You current working directory will be:\n")
   cat(path)
 
-  if (confirm) {
+  if (confirm && interactive()) {
     user_input <- tolower(
       readline(
         prompt = "Do you wish to create a project template here? (y/yes to confirm): "

--- a/R/init_tool_review.R
+++ b/R/init_tool_review.R
@@ -23,7 +23,7 @@ tool_review_template <- function(
   cat("You current working directory will be:\n")
   cat(path)
 
-  if (confirm) {
+  if (confirm && interactive()) {
     user_input <- tolower(
       readline(
         prompt = "Do you wish to create a project template here? (y/yes to confirm): "

--- a/man/init_changelog_md.Rd
+++ b/man/init_changelog_md.Rd
@@ -18,5 +18,5 @@ Return markdown file in specified or current working directory
 A changelog markdown template to document project progress
 }
 \examples{
-init_changelog_md()
+init_changelog_md(path = tempdir(), confirm = FALSE)
 }

--- a/tests/testthat/test-init_changelog_md.R
+++ b/tests/testthat/test-init_changelog_md.R
@@ -9,3 +9,18 @@ test_that("init_changelog_md() writes a non-empty CHANGELOG.md at the given path
   expect_true(file.exists(changelog))
   expect_gt(file.size(changelog), 0)
 })
+
+test_that("init_changelog_md() proceeds without prompting in non-interactive use", {
+  # With confirm = TRUE in a non-interactive session, readline() previously
+  # returned "" and the function silently cancelled. The interactive() guard
+  # makes it proceed instead. testthat runs non-interactively.
+  skip_if(interactive())
+
+  dir <- file.path(tempdir(), "peacock-changelog-noninteractive")
+  dir.create(dir, showWarnings = FALSE)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  init_changelog_md(path = dir, confirm = TRUE)
+
+  expect_true(file.exists(file.path(dir, "CHANGELOG.md")))
+})


### PR DESCRIPTION
Guards the `readline()` confirmation prompt behind `interactive()` in all four `init_*`/`tool_review_template` functions.

**Problem:** with `confirm = TRUE` (the default) in a non-interactive session (scripts, R CMD check, CI), `readline()` returns `""`, so the functions silently did nothing.

**Change:** `if (confirm)` -> `if (confirm && interactive())`. Interactive users still get the prompt; non-interactive callers now proceed (equivalent to `confirm = FALSE`) instead of silently cancelling.

Also makes the `init_changelog_md()` example safe and runnable: `init_changelog_md(path = tempdir(), confirm = FALSE)` (previously `init_changelog_md()` — the only example not wrapped in `\dontrun{}`), so it no longer risks writing to the working directory during checks.

**Test:** new regression test asserts `confirm = TRUE` in a non-interactive session writes the file (would have cancelled before this fix).