### PR TITLE
fix: populate empty src scripts in tool_review_template()

### DIFF
--- a/R/init_tool_review.R
+++ b/R/init_tool_review.R
@@ -79,27 +79,17 @@ tool_review_template <- function(
       if (x == "src") {
         sapply(seq_along(tool_name), function(x) {
           bb <- file.path(aa, paste0(tool_name[x], ".R"))
-          if (file.exists(bb)) {
-            file_info <- file.info(bb)
-            if (is.na(file_info$size) || file_info$size == 0) {
-              # fileConn <- file(bb)
-              # writeLines(
-              #   script_comment(tool_name[x], tool_url[x]),
-              #   fileConn
-              # )
-              # close(fileConn)
-              cat("The file is empty. No changes made.\n")
-            } else {
-              cat("The file is not empty. No changes made.\n")
-            }
-          } else {
-            file.create(bb, showWarnings = FALSE)
+          info <- file.info(bb)
+          # Write the tool header into new or empty files; never overwrite content.
+          if (!file.exists(bb) || is.na(info$size) || info$size == 0) {
             fileConn <- file(bb)
             writeLines(
               script_comment(tool_name[x], tool_url[x]),
               fileConn
             )
             close(fileConn)
+          } else {
+            cat("The file is not empty. No changes made.\n")
           }
         })
       }

--- a/tests/testthat/test-init_tool_review.R
+++ b/tests/testthat/test-init_tool_review.R
@@ -16,3 +16,49 @@ test_that("tool_review_template() handles zero tools without error", {
   )
   expect_length(list.files(file.path(dir, "src"), pattern = "\\.R$"), 0)
 })
+
+test_that("tool_review_template() creates a src script with the tool header", {
+  dir <- file.path(tempdir(), "peacock-toolrev-new")
+  dir.create(dir, showWarnings = FALSE)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  tool_review_template(
+    "toolA",
+    "https://a.example",
+    path = dir,
+    confirm = FALSE
+  )
+
+  lines <- readLines(file.path(dir, "src", "toolA.R"))
+  expect_true(any(grepl("Tool name: toolA", lines, fixed = TRUE)))
+  expect_true(any(grepl("https://a.example", lines, fixed = TRUE)))
+})
+
+test_that("tool_review_template() populates an empty existing src script", {
+  dir <- file.path(tempdir(), "peacock-toolrev-emptysrc")
+  dir.create(file.path(dir, "src"), recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  file.create(file.path(dir, "src", "toolB.R")) # empty file
+
+  tool_review_template(
+    "toolB",
+    "https://b.example",
+    path = dir,
+    confirm = FALSE
+  )
+
+  lines <- readLines(file.path(dir, "src", "toolB.R"))
+  expect_true(any(grepl("Tool name: toolB", lines, fixed = TRUE)))
+})
+
+test_that("tool_review_template() leaves a non-empty src script unchanged", {
+  dir <- file.path(tempdir(), "peacock-toolrev-nonempty")
+  dir.create(file.path(dir, "src"), recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  existing <- "# my own code"
+  writeLines(existing, file.path(dir, "src", "toolC.R"))
+
+  tool_review_template("toolC", "", path = dir, confirm = FALSE)
+
+  expect_identical(readLines(file.path(dir, "src", "toolC.R")), existing)
+})


### PR DESCRIPTION
Completes a feature that was left commented out: when a per-tool `src/<tool>.R` already existed but was **empty**, the function just printed `"The file is empty. No changes made."` and skipped it (the writing code was commented out).

Now new **and** empty existing scripts get the tool header comment; non-empty scripts are still left untouched. This also removes the dead commented block and the redundant `file.exists` branch.

**Tests:** new script gets the header; empty existing script gets populated; non-empty script is left unchanged.