### PR TITLE
chore: doc and message cleanup

### DIFF
--- a/R/init_changelog_md.R
+++ b/R/init_changelog_md.R
@@ -10,7 +10,7 @@
 #' init_changelog_md(path = tempdir(), confirm = FALSE)
 init_changelog_md <- function(path = getwd(), confirm = TRUE) {
   # Display a message before the prompt
-  cat("You current working directory will be:\n")
+  cat("Your current working directory will be:\n")
   cat(path)
 
   if (confirm && interactive()) {

--- a/R/init_shiny.R
+++ b/R/init_shiny.R
@@ -12,7 +12,7 @@
 #' @export
 init_shiny <- function(path = getwd(), confirm = TRUE) {
   # Display a message before the prompt
-  cat("You current working directory will be:\n")
+  cat("Your current working directory will be:\n")
   cat(path)
 
   if (confirm && interactive()) {

--- a/R/init_template.R
+++ b/R/init_template.R
@@ -12,7 +12,6 @@
 #' \dontrun{
 #' init_template("shiny",getwd())
 #' }
-#' @keywords internal
 init_template <- function(
   template_name = c("shiny", "cgds"),
   path = getwd(),
@@ -21,7 +20,7 @@ init_template <- function(
   template_name <- match.arg(template_name)
 
   # Display a message before the prompt
-  cat("You current working directory will be:\n")
+  cat("Your current working directory will be:\n")
   cat(path)
 
   if (confirm && interactive()) {

--- a/R/init_tool_review.R
+++ b/R/init_tool_review.R
@@ -20,7 +20,7 @@ tool_review_template <- function(
   confirm = TRUE,
   ...
 ) {
-  cat("You current working directory will be:\n")
+  cat("Your current working directory will be:\n")
   cat(path)
 
   if (confirm && interactive()) {
@@ -35,7 +35,7 @@ tool_review_template <- function(
 
   if (user_input %in% c("y", "yes")) {
     if (length(tool_name) != length(tool_url)) {
-      print("Please provide URL or Empty qoutes for Each tool")
+      print("Please provide a URL or empty quotes for each tool")
       return(invisible(NULL))
     }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,6 +16,8 @@ knitr::opts_chunk$set(
 # peacock
 
 <!-- badges: start -->
+[![R-CMD-check](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
 peacock helps you quickly set up new R projects with pre-configured directory structures and files. Stop creating the same folders and files manually every time you start a project. Just run a function and get working.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 <!-- badges: start -->
 
+[![R-CMD-check](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
 peacock helps you quickly set up new R projects with pre-configured directory structures and files. Stop creating the same folders and files manually every time you start a project. Just run a function and get working.

--- a/man/init_template.Rd
+++ b/man/init_template.Rd
@@ -24,4 +24,3 @@ Initialize a template repository from GitHub Templates
 init_template("shiny",getwd())
 }
 }
-\keyword{internal}


### PR DESCRIPTION
Small polish pass (no behavior change):

- Fix `"You current working directory"` -> `"Your ..."` in all four functions, and `"Empty qoutes for Each tool"` -> `"empty quotes for each tool"` in `tool_review_template()`.
- Remove the contradictory `@keywords internal` from `init_template()` (it is exported) and from its `.Rd`.
- Add **R-CMD-check** and **lifecycle: experimental** badges to `README.Rmd`/`README.md` (previously an empty badges block). README.md hand-synced since R isn't available to run `build_readme()`.