### PR TITLE
feat: AI-native scaffolds (AGENTS.md / CLAUDE.md)

### DIFF
--- a/R/agents.R
+++ b/R/agents.R
@@ -1,0 +1,26 @@
+# Write AGENTS.md (the source of truth) plus a CLAUDE.md that imports it, so both
+# cross-tool agents and Claude Code pick up the project's guidance.
+#
+# @param path Project directory.
+# @param lines Character vector of AGENTS.md contents.
+# @return Invisibly, `path`.
+write_agent_files <- function(path, lines) {
+  agents <- file(file.path(path, "AGENTS.md"))
+  writeLines(lines, agents)
+  close(agents)
+
+  claude <- file(file.path(path, "CLAUDE.md"))
+  writeLines(
+    c(
+      "# Agent guidance",
+      "",
+      "This project's agent instructions live in [AGENTS.md](AGENTS.md).",
+      "",
+      "@AGENTS.md"
+    ),
+    claude
+  )
+  close(claude)
+
+  invisible(path)
+}

--- a/R/init_analysis.R
+++ b/R/init_analysis.R
@@ -115,6 +115,28 @@ init_analysis <- function(path = getwd(), confirm = TRUE) {
     )
   )
 
+  write_agent_files(
+    path,
+    c(
+      "# Analysis project - agent guide",
+      "",
+      "A reproducible analysis project scaffolded with peacock.",
+      "",
+      "## Workflow",
+      "",
+      "- Put original inputs in `data/raw/` and treat them as read-only.",
+      "- Write cleaned or derived data to `data/processed/`.",
+      "- Do the analysis in `analysis/*.qmd` notebooks; build with `quarto render`.",
+      "- Keep reusable functions in `R/` and `source()` them from notebooks.",
+      "- Save results to `output/figures/` and `output/tables/`.",
+      "",
+      "## Conventions",
+      "",
+      "- Never edit files in `data/raw/`.",
+      "- Prefer functions in `R/` over copy-pasting code between notebooks."
+    )
+  )
+
   cat("Analysis project initialized.\n")
   invisible(path)
 }

--- a/R/init_quarto.R
+++ b/R/init_quarto.R
@@ -167,6 +167,25 @@ init_quarto <- function(
     write_file("references.bib", bib_stub())
   }
 
+  write_agent_files(
+    path,
+    c(
+      paste0("# Quarto ", type, " - agent guide"),
+      "",
+      paste0("A Quarto ", type, " scaffolded with peacock."),
+      "",
+      "## Build",
+      "",
+      "- `quarto preview` for a live preview; `quarto render` to build.",
+      "",
+      "## Layout",
+      "",
+      "- `_quarto.yml` - project and format configuration.",
+      "- `index.qmd` - the entry document.",
+      "- Add pages or chapters as `.qmd` files and register them in `_quarto.yml`."
+    )
+  )
+
   cat("Quarto", type, "project initialized.\n")
   invisible(path)
 }

--- a/R/init_shiny.R
+++ b/R/init_shiny.R
@@ -189,6 +189,33 @@ init_shiny <- function(path = getwd(), confirm = TRUE) {
         close(fileConn)
       }
     })
+
+    write_agent_files(
+      wd_path,
+      c(
+        "# Shiny app - agent guide",
+        "",
+        "A Shiny application scaffolded with peacock.",
+        "",
+        "## Run",
+        "",
+        "- `shiny::runApp()` from the project root (or Run App in RStudio).",
+        "",
+        "## Layout",
+        "",
+        "- `ui.R`, `server.R`, `global.R` - app entry points.",
+        "- `modules/` - Shiny modules; `userInterface/` - page UIs.",
+        "- `R/load_components.R` sources modules and UI automatically.",
+        "- `www/` - static assets (css, img, js); `data/` - data files.",
+        "",
+        "## Conventions",
+        "",
+        "- Add a page as `userInterface/<page>_ui.R` and reference it in `ui.R`.",
+        "- Put secrets in `.Renviron` (never commit real values).",
+        "- `Dockerfile` builds on `rocker/shiny` and exposes port 3838."
+      )
+    )
+
     cat("Project initialized.\n")
     cat("Please see documentation at:\n")
     cat("https://www.samuelbharti.com/posts/r-shiny-template/")

--- a/README.Rmd
+++ b/README.Rmd
@@ -128,6 +128,12 @@ init_quarto(path = "my_site", type = "website")
 `type` can be `"website"` (default), `"book"`, or `"manuscript"`; each gets a
 `_quarto.yml` and starter documents.
 
+### Every project is AI-ready
+
+`init_shiny()`, `init_analysis()`, and `init_quarto()` also drop an `AGENTS.md`
+(plus a `CLAUDE.md` that imports it) describing how to run, build, and work in the
+project — so AI coding assistants are productive from the first commit.
+
 ## Quick start
 
 ```{r eval = FALSE}

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ init_quarto(path = "my_site", type = "website")
 `type` can be `"website"` (default), `"book"`, or `"manuscript"`; each gets a
 `_quarto.yml` and starter documents.
 
+### Every project is AI-ready
+
+`init_shiny()`, `init_analysis()`, and `init_quarto()` also drop an `AGENTS.md`
+(plus a `CLAUDE.md` that imports it) describing how to run, build, and work in the
+project — so AI coding assistants are productive from the first commit.
+
 ## RStudio Integration
 
 Once installed, peacock adds an RStudio Add-in for quick access:

--- a/tests/testthat/test-init_analysis.R
+++ b/tests/testthat/test-init_analysis.R
@@ -18,4 +18,12 @@ test_that("init_analysis() scaffolds the expected structure", {
   expect_true(file.exists(file.path(dir, "R", "functions.R")))
   expect_true(file.exists(file.path(dir, "analysis", "notebook.qmd")))
   expect_true(file.exists(file.path(dir, "data", "raw", ".gitkeep")))
+
+  # AI-native: agent guidance files
+  expect_true(file.exists(file.path(dir, "AGENTS.md")))
+  expect_true(file.exists(file.path(dir, "CLAUDE.md")))
+  expect_match(
+    paste(readLines(file.path(dir, "AGENTS.md")), collapse = "\n"),
+    "agent guide"
+  )
 })

--- a/tests/testthat/test-init_quarto.R
+++ b/tests/testthat/test-init_quarto.R
@@ -12,6 +12,8 @@ test_that("init_quarto() scaffolds a website by default", {
     paste(readLines(file.path(dir, "_quarto.yml")), collapse = "\n"),
     "type: website"
   )
+  expect_true(file.exists(file.path(dir, "AGENTS.md")))
+  expect_true(file.exists(file.path(dir, "CLAUDE.md")))
 })
 
 test_that("init_quarto() scaffolds a book with a bibliography", {

--- a/tests/testthat/test-init_shiny.R
+++ b/tests/testthat/test-init_shiny.R
@@ -13,3 +13,14 @@ test_that("init_shiny() writes a Dockerfile with a valid CMD (no backtick quotin
   expect_no_match(cmd, "`", fixed = TRUE)
   expect_match(cmd, "/home/my_app", fixed = TRUE)
 })
+
+test_that("init_shiny() drops AGENTS.md and CLAUDE.md", {
+  dir <- file.path(tempdir(), "peacock-shiny-agents")
+  dir.create(dir, showWarnings = FALSE)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  init_shiny(path = dir, confirm = FALSE)
+
+  expect_true(file.exists(file.path(dir, "AGENTS.md")))
+  expect_true(file.exists(file.path(dir, "CLAUDE.md")))
+})


### PR DESCRIPTION
Phase 3. Every project scaffold now drops agent guidance so AI coding assistants are productive immediately.

**What changes**
- New internal `write_agent_files()` writes `AGENTS.md` (the source of truth) plus a `CLAUDE.md` that imports it (`@AGENTS.md`) — covering both cross-tool agents and Claude Code.
- `init_shiny()`, `init_analysis()`, and `init_quarto()` each emit an `AGENTS.md` tailored to that project: how to run/build, the layout, and conventions. Content is thin and real (the actual run/build loop).
- Extends the existing `docs/llms.txt` habit.

**Tests:** each scaffold's test now asserts `AGENTS.md`/`CLAUDE.md` are created (+ a content check on the analysis guide).

_tool_review_template() can get the same treatment in a fast follow if wanted._