### PR TITLE
feat: AI-native tool_review_template()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,9 +18,9 @@
 * `init_python()` emits a modern Python project (src layout, `pyproject.toml` with
   ruff and pytest). peacock stays an R package.
 
-* `init_shiny()`, `init_analysis()`, `init_quarto()`, and `init_python()` now also
-  write `AGENTS.md` and `CLAUDE.md` so AI coding assistants are productive
-  immediately.
+* Every project scaffold - `init_shiny()`, `init_analysis()`, `init_quarto()`,
+  `init_python()`, and `tool_review_template()` - now also writes `AGENTS.md` and
+  `CLAUDE.md` so AI coding assistants are productive immediately.
 
 ## Reliability
 

--- a/R/init_tool_review.R
+++ b/R/init_tool_review.R
@@ -94,6 +94,28 @@ tool_review_template <- function(
         })
       }
     })
+
+    write_agent_files(
+      wd_path,
+      c(
+        "# Tool review project - agent guide",
+        "",
+        "A tool/method comparison project scaffolded with peacock.",
+        "",
+        "## Layout",
+        "",
+        "- `src/<tool>.R` - one script per tool (headed with its name and URL).",
+        "- `data/shared/` - inputs used by all tools (read-only).",
+        "- `data/preprocessed/<tool>/` - per-tool prepared data; `data/other/`.",
+        "- `out/<tool>/` - per-tool outputs.",
+        "- `notebooks/`, `configs/`, `docs/` - analysis, config, and write-ups.",
+        "",
+        "## Conventions",
+        "",
+        "- Keep shared inputs in `data/shared/` and treat them as read-only.",
+        "- Put each tool's results under `out/<tool>/`."
+      )
+    )
   } else {
     cat("Project initialization canceled.\n")
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -141,7 +141,7 @@ module and test, `.gitignore`, and `AGENTS.md`.
 
 ### Every project is AI-ready
 
-`init_shiny()`, `init_analysis()`, `init_quarto()`, and `init_python()` also drop an `AGENTS.md`
+peacock's project scaffolds all drop an `AGENTS.md`
 (plus a `CLAUDE.md` that imports it) describing how to run, build, and work in the
 project — so AI coding assistants are productive from the first commit.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ module and test, `.gitignore`, and `AGENTS.md`.
 
 ### Every project is AI-ready
 
-`init_shiny()`, `init_analysis()`, `init_quarto()`, and `init_python()` also drop an `AGENTS.md`
+peacock's project scaffolds all drop an `AGENTS.md`
 (plus a `CLAUDE.md` that imports it) describing how to run, build, and work in the
 project — so AI coding assistants are productive from the first commit.
 

--- a/tests/testthat/test-init_tool_review.R
+++ b/tests/testthat/test-init_tool_review.R
@@ -32,6 +32,10 @@ test_that("tool_review_template() creates a src script with the tool header", {
   lines <- readLines(file.path(dir, "src", "toolA.R"))
   expect_true(any(grepl("Tool name: toolA", lines, fixed = TRUE)))
   expect_true(any(grepl("https://a.example", lines, fixed = TRUE)))
+
+  # AI-native: agent guidance files
+  expect_true(file.exists(file.path(dir, "AGENTS.md")))
+  expect_true(file.exists(file.path(dir, "CLAUDE.md")))
 })
 
 test_that("tool_review_template() populates an empty existing src script", {


### PR DESCRIPTION
Completes the AI-native story: `tool_review_template()` was the one project scaffold not yet emitting agent guidance. It now writes `AGENTS.md` (describing the src/data/out layout and conventions) plus `CLAUDE.md`, via the shared `write_agent_files()` helper.

**Test:** the src-script test now also asserts `AGENTS.md`/`CLAUDE.md` are created.

Also updates the 0.2.0 NEWS bullet and the README note to reflect that every project scaffold is AI-ready.