### PR TITLE
docs: regenerate README and man pages from source

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,6 @@ Description: Streamline project setup by initializing directory structures
 License: GPL-3 + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.3
 Suggests:
     knitr,
     rmarkdown,
@@ -24,3 +23,4 @@ Imports:
     utils
 URL: http://www.samuelbharti.com/peacock/, https://github.com/samuelbharti/peacock
 BugReports: https://github.com/samuelbharti/peacock/issues
+Config/roxygen2/version: 8.0.0

--- a/R/templates.R
+++ b/R/templates.R
@@ -67,7 +67,7 @@ read_registry <- function(registry = NULL) {
 #'
 #' @param template_name Registry name or `"owner/repo"` / `"owner/repo@ref"`.
 #' @param ref Optional branch/tag/SHA override.
-#' @param registry Optional custom registry path (see [read_registry()]).
+#' @param registry Optional custom registry path (see `read_registry()`).
 #' @return A list with `repo`, `ref`, and `doc_url`.
 #' @noRd
 resolve_template <- function(template_name, ref = NULL, registry = NULL) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -58,6 +58,7 @@ init_shiny(path = "my_shiny_app")
 ```
 
 This creates:
+
 - `ui.R`, `server.R`, `global.R` - Your main Shiny files
 - `modules/` - For modular Shiny components
 - `userInterface/` - UI components organized separately
@@ -93,6 +94,8 @@ init_template("owner/repo@dev", path = "my_project")
 # See the built-in templates
 peacock_templates()
 ```
+
+The CGDS template is part of the [UAB CGDS research workflow](https://github.com/uab-cgds-worthey/cgds_repo_template).
 
 ### 4. Set up tool review projects
 
@@ -147,6 +150,13 @@ peacock's project scaffolds all drop an `AGENTS.md`
 (plus a `CLAUDE.md` that imports it) describing how to run, build, and work in the
 project — so AI coding assistants are productive from the first commit.
 
+## RStudio Integration
+
+Once installed, peacock adds an RStudio Add-in for quick access:
+
+- Find "Peacock: Shiny Template" in the Addins menu
+- Or create a new project and select "Peacock: Shiny Template" from the templates
+
 ## Quick start
 
 ```{r eval = FALSE}
@@ -164,6 +174,7 @@ Set `confirm = FALSE` to skip the confirmation prompt (useful for scripting).
 ## Learn more
 
 - Full documentation: http://www.samuelbharti.com/peacock/
+- Vignette: `vignette("introduction")`
 - Issues and feedback: https://github.com/samuelbharti/peacock/issues
 
 ## License

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 
 <!-- badges: start -->
 
-[![R-CMD-check](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml)
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-<!-- badges: end -->
+[![R-CMD-check](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml) [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental) <!-- badges: end -->
 
 peacock helps you quickly set up new R projects with pre-configured directory structures and files. Stop creating the same folders and files manually every time you start a project. Just run a function and get working.
 
@@ -47,6 +45,7 @@ init_shiny(path = "my_shiny_app")
 ```
 
 This creates:
+
 - `ui.R`, `server.R`, `global.R` - Your main Shiny files
 - `modules/` - For modular Shiny components
 - `userInterface/` - UI components organized separately
@@ -67,8 +66,7 @@ Creates a `CHANGELOG.md` file with a simple format for documenting your work.
 
 ### 3. Use GitHub templates
 
-Pull down complete project templates from GitHub. Use a built-in name, or **any**
-GitHub repository as `"owner/repo"` (optionally pinned with `"owner/repo@ref"`).
+Pull down complete project templates from GitHub. Use a built-in name, or **any** GitHub repository as `"owner/repo"` (optionally pinned with `"owner/repo@ref"`).
 
 ``` r
 # Built-in templates
@@ -107,8 +105,7 @@ Set up a tidy layout for a data-analysis or research project.
 init_analysis(path = "my_study")
 ```
 
-Creates `data/{raw,processed}`, `R/`, `analysis/` (with a starter Quarto notebook),
-and `output/{figures,tables}`, plus a README and `.gitignore`.
+Creates `data/{raw,processed}`, `R/`, `analysis/` (with a starter Quarto notebook), and `output/{figures,tables}`, plus a README and `.gitignore`.
 
 ### 6. Scaffold a Quarto project
 
@@ -118,8 +115,7 @@ Create a Quarto website, book, or manuscript.
 init_quarto(path = "my_site", type = "website")
 ```
 
-`type` can be `"website"` (default), `"book"`, or `"manuscript"`; each gets a
-`_quarto.yml` and starter documents.
+`type` can be `"website"` (default), `"book"`, or `"manuscript"`; each gets a `_quarto.yml` and starter documents.
 
 ### 7. Scaffold a Python project
 
@@ -129,20 +125,18 @@ peacock stays an R package, but it can emit a Python project too.
 init_python(path = "my_pkg")
 ```
 
-Creates a src-layout package with `pyproject.toml` (ruff + pytest), a starter
-module and test, `.gitignore`, and `AGENTS.md`.
+Creates a src-layout package with `pyproject.toml` (ruff + pytest), a starter module and test, `.gitignore`, and `AGENTS.md`.
 
 ### Every project is AI-ready
 
-peacock's project scaffolds all drop an `AGENTS.md`
-(plus a `CLAUDE.md` that imports it) describing how to run, build, and work in the
-project — so AI coding assistants are productive from the first commit.
+peacock’s project scaffolds all drop an `AGENTS.md` (plus a `CLAUDE.md` that imports it) describing how to run, build, and work in the project — so AI coding assistants are productive from the first commit.
 
 ## RStudio Integration
 
 Once installed, peacock adds an RStudio Add-in for quick access:
-- Find "Peacock: Shiny Template" in the Addins menu
-- Or create a new project and select "Peacock: Shiny Template" from the templates
+
+- Find “Peacock: Shiny Template” in the Addins menu
+- Or create a new project and select “Peacock: Shiny Template” from the templates
 
 ## Quick start
 
@@ -160,9 +154,9 @@ Set `confirm = FALSE` to skip the confirmation prompt (useful for scripting).
 
 ## Learn more
 
-- Full documentation: http://www.samuelbharti.com/peacock/
+- Full documentation: <http://www.samuelbharti.com/peacock/>
 - Vignette: `vignette("introduction")`
-- Issues and feedback: https://github.com/samuelbharti/peacock/issues
+- Issues and feedback: <https://github.com/samuelbharti/peacock/issues>
 
 ## License
 

--- a/man/init_quarto.Rd
+++ b/man/init_quarto.Rd
@@ -23,7 +23,7 @@ Invisibly, the \code{path} the project was created in.
 }
 \description{
 Scaffolds a starter \href{https://quarto.org}{Quarto} project: a website, a book,
-or a manuscript, with a \code{_quarto.yml} and starter documents.
+or a manuscript, with a \verb{_quarto.yml} and starter documents.
 }
 \examples{
 init_quarto(path = tempdir(), confirm = FALSE)

--- a/man/init_template.Rd
+++ b/man/init_template.Rd
@@ -18,7 +18,7 @@ GitHub repository as \code{"owner/repo"} / \code{"owner/repo@ref"}. Defaults to 
 
 \item{path}{Path where the project template will be created.}
 
-\item{ref}{Optional branch, tag, or commit to download. Overrides an \code{@ref}
+\item{ref}{Optional branch, tag, or commit to download. Overrides an \verb{@ref}
 given in \code{template_name}. Defaults to the template's registry ref, or the
 repository's default branch (\code{HEAD}).}
 

--- a/man/peacock-package.Rd
+++ b/man/peacock-package.Rd
@@ -6,6 +6,8 @@
 \alias{peacock-package}
 \title{peacock: Quick Project Initialization with Templates}
 \description{
+\if{html}{\figure{logo.svg}{options: style='float: right' alt='logo' width='120'}}
+
 Streamline project setup by initializing directory structures with pre-configured templates. Create Shiny applications, research projects, and tool comparison studies with organized folders and starter files. Stop recreating the same structure manually and start coding faster.
 }
 \seealso{
@@ -19,6 +21,11 @@ Useful links:
 }
 \author{
 \strong{Maintainer}: Samuel Bharti \email{samuelbharti@gmail.com}
+
+Authors:
+\itemize{
+  \item Samuel Bharti \email{samuelbharti@gmail.com}
+}
 
 }
 \keyword{internal}

--- a/man/peacock_templates.Rd
+++ b/man/peacock_templates.Rd
@@ -18,7 +18,7 @@ and \code{Description}.
 \description{
 Returns the registry of curated templates that \code{\link[=init_template]{init_template()}} understands
 by short name. You can also pass any GitHub \code{"owner/repo"} (optionally
-\code{"owner/repo@ref"}) to \code{\link[=init_template]{init_template()}} without it being in this registry.
+\code{"owner/repo@ref"}) to \code{init_template()} without it being in this registry.
 }
 \examples{
 peacock_templates()


### PR DESCRIPTION
Uses a local R 4.6.1 toolchain (roxygen2 8.0.0, rmarkdown, testthat) to regenerate the generated docs from source instead of hand-syncing them, and fixes the drift that had accumulated.

## man/ + DESCRIPTION (roxygen2 8.0.0)
- Regenerated all `.Rd` from the roxygen source. Real fixes vs the hand-synced versions: the package doc page now shows the logo (`\figure{logo.svg}`) and the full author block; backtick spans with `@`/`_` render as `\verb` rather than `\code`.
- DESCRIPTION: `RoxygenNote` field replaced by `Config/roxygen2/version: 8.0.0` (roxygen2 8 rename).
- Made the internal `read_registry()` reference in `resolve_template()`'s `@noRd` block a plain code span so `roxygenise()` runs warning-free.

## README
- README.Rmd had drifted **behind** README.md. Ported the missing content back into the source: the CGDS workflow note, the RStudio Integration section, and the vignette link. Added the blank line before the "This creates:" list (pandoc collapsed it into prose without it).
- Regenerated README.md from README.Rmd (`--wrap=none`). Remaining diff is normal github_document output (smart quotes, `<url>` autolinks).

Test suite passes locally (`testthat::test_local()`), in addition to CI.