### PR TITLE
chore: add author ORCID to citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "creators": [
     {
-      "name": "Bharti, Samuel"
+      "name": "Bharti, Samuel",
+      "orcid": "0000-0003-4190-7058"
     }
   ],
   "keywords": [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,7 @@ authors:
   - family-names: Bharti
     given-names: Samuel
     email: samuelbharti@gmail.com
+    orcid: "https://orcid.org/0000-0003-4190-7058"
 version: 0.2.0
 date-released: "2026-07-14"
 license: MIT


### PR DESCRIPTION
Adds Samuel Bharti's ORCID (0000-0003-4190-7058) to `CITATION.cff` (full URL) and `.zenodo.json` (bare ID) so it's captured on the Zenodo record and the GitHub citation. Prep for the v0.2.0 release.