### PR TITLE
docs: complete NEWS for 0.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,11 @@
 
 ## Other
 
+* peacock is now released under the MIT license (previously GPL-3).
+
+* Added a package hex-sticker logo (in an Indian folk-art style), a companion
+  overview graphic, and browser-tab favicons for the documentation site.
+
 * The `init_*` scaffolding functions now return the created `path` invisibly.
 
 # peacock 0.1.0


### PR DESCRIPTION
Adds the MIT relicense and the new logo/overview/favicons to the 0.2.0 changelog so the release notes are complete before tagging.