### PR TITLE
docs: add Zenodo DOI badge and citation DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,6 +13,7 @@ authors:
     orcid: "https://orcid.org/0000-0003-4190-7058"
 version: 0.2.0
 date-released: "2026-07-14"
+doi: 10.5281/zenodo.21350436
 license: MIT
 repository-code: "https://github.com/samuelbharti/peacock"
 url: "http://www.samuelbharti.com/peacock/"

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,6 +18,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml)
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21350436.svg)](https://doi.org/10.5281/zenodo.21350436)
 <!-- badges: end -->
 
 peacock helps you quickly set up new R projects with pre-configured directory structures and files. Stop creating the same folders and files manually every time you start a project. Just run a function and get working.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <!-- badges: start -->
 
-[![R-CMD-check](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml) [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental) <!-- badges: end -->
+[![R-CMD-check](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/samuelbharti/peacock/actions/workflows/R-CMD-check.yaml) [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21350436.svg)](https://doi.org/10.5281/zenodo.21350436) <!-- badges: end -->
 
 peacock helps you quickly set up new R projects with pre-configured directory structures and files. Stop creating the same folders and files manually every time you start a project. Just run a function and get working.
 


### PR DESCRIPTION
peacock v0.2.0 is archived on Zenodo. Adds the concept-DOI badge (`10.5281/zenodo.21350436`, always resolves to the latest version) to the README and `doi:` to `CITATION.cff`.

Record: https://zenodo.org/records/21350437 — title, version v0.2.0, MIT license, and ORCID all confirmed present.